### PR TITLE
gitm.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -728,6 +728,7 @@ var cnames_active = {
   "girlscript": "girlscriptjaipur.github.io",
   "gitdown": "gc.github.io/gitdown",
   "gitinit": "silly-shirley-8e44e3.netlify.com",
+  "gitm" : "gitm.netlify.com",
   "gitme": "gitme.netlify.com",
   "gitmoji": "jeff-tian.github.io/gitmoji",
   "gitstyle": "inKerk.github.io/git-style-guide",


### PR DESCRIPTION
added gitm.netlify.com for gitm.js.org

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
